### PR TITLE
change scope applies to applyAsync

### DIFF
--- a/src/ng-quill.js
+++ b/src/ng-quill.js
@@ -155,7 +155,7 @@
                     if (range) {
                         return;
                     }
-                    $scope.$apply(function () {
+                    $scope.$applyAsync(function () {
                         this.ngModelCtrl.$setTouched();
                     }.bind(this));
                 }.bind(this));
@@ -171,7 +171,7 @@
                     this.validate(text);
 
                     if (!modelChanged) {
-                        $scope.$apply(function () {
+                        $scope.$applyAsync(function () {
                             editorChanged = true;
 
                             this.ngModelCtrl.$setViewValue(html);


### PR DESCRIPTION
I did this once before on the 0.2x branch. `$scope.$apply` is causing `$apply already in progress` errors in the console when I try to use `editor.clipboard.dangerouslyPasteHTML()`. Using `$applyAsync` will wait for the current digest cycle to finish before triggering another.