### PR TITLE
Main path in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ngQuill",
   "version": "2.0.2",
-  "main": ["src/ng-quill.min.js"],
+  "main": ["dist/ng-quill.min.js"],
   "description": "AngularJS directive for the QuillJS rich text editor",
   "authors": [
     "Bengt Weiße <bengtler@gmail.com>"


### PR DESCRIPTION
Path was incorrect, thus not allowing usage of tools like "main-bower-files"