### PR TITLE
Fix typo stemming from changing boundary to bounds.

### DIFF
--- a/src/ng-quill.js
+++ b/src/ng-quill.js
@@ -147,7 +147,7 @@
           modules: this.modules || ngQuillConfig.modules,
           formats: this.formats || ngQuillConfig.formats,
           placeholder: this.placeholder || ngQuillConfig.placeholder,
-          boundy: ngQuillConfig.bounds
+          bounds: ngQuillConfig.bounds
         }
       }
 


### PR DESCRIPTION
A typo was committed when switching from boundary to bounds in the quill configuration. This fixes that typo.