### PR TITLE
Improvements to the empty text verification; added 'toRegister' to customOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bower_components
 node_modules
 coverage
 dist
+.idea

--- a/demo.html
+++ b/demo.html
@@ -49,6 +49,10 @@
                 import: 'attributors/style/size',
                 whitelist: ['14', '16', '18', 'small', 'large', 'huge']
               }]
+              $scope.customTag = [{
+                  import: 'blots/block',
+                  toRegister: {key: 'tagName', value: 'DIV'}
+              }]
               $scope.customModules = {
                 toolbar: [
                   [{'size': [false, '14', '16', '18']}]
@@ -79,7 +83,7 @@
 
         <h3>Default editor + Callbacks/Outputs in JS console and empty init model</h3>
         <pre><code>{{model}}</code></pre>
-        <ng-quill-editor ng-model="model" placeholder="override default placeholder" on-editor-created="editorCreated(editor)" on-content-changed="contentChanged(editor, html, text)" on-selection-changed="selectionChanged(editor, range, oldRange, source)"></ng-quill-editor>
+        <ng-quill-editor custom-options="customTag" ng-model="model" placeholder="override default placeholder" on-editor-created="editorCreated(editor)" on-content-changed="contentChanged(editor, html, text)" on-selection-changed="selectionChanged(editor, range, oldRange, source)"></ng-quill-editor>
 
         <h3>Bubble editor</h3>
         <ng-quill-editor theme="bubble" ng-model="title"></ng-quill-editor>

--- a/src/ng-quill.js
+++ b/src/ng-quill.js
@@ -191,6 +191,9 @@
           this.customOptions.forEach(function (customOption) {
             var newCustomOption = Quill.import(customOption.import)
             newCustomOption.whitelist = customOption.whitelist
+            if (customOption.toRegister) {
+              newCustomOption[customOption.toRegister.key] = customOption.toRegister.value;
+            }
             Quill.register(newCustomOption, true)
           })
         }
@@ -222,9 +225,10 @@
         editor.on('text-change', function (delta, oldDelta, source) {
           var html = editorElem.children[0].innerHTML
           var text = editor.getText()
+          var emptyModelTag = ['<' + editor.root.firstChild.localName + '>', '</' + editor.root.firstChild.localName + '>']
 
-          if (html === '<p><br></p>') {
-            html = null
+          if (html === emptyModelTag[0] + '<br>' + emptyModelTag[1]) {
+              html = null
           }
           this.validate(text)
 


### PR DESCRIPTION
- The verification that checks if the text is empty uses the default tag element from Quill
- Added 'toRegister' option to the 'customOptions' so we can register and change a property value inside ng-quill instead of doing that globally.