### PR TITLE
FIX: incompatibility with LanguageTool browser extension

### DIFF
--- a/src/ng-quill.js
+++ b/src/ng-quill.js
@@ -294,7 +294,7 @@
 
         // update model if text changes
         textChangeEvent = editor.on('text-change', function (delta, oldDelta, source) {
-          var html = editorElem.children[0].innerHTML
+          var html = editorElem.querySelector(".ql-editor").innerHTML
           var text = editor.getText()
           var content = editor.getContents()
 

--- a/src/ng-quill.js
+++ b/src/ng-quill.js
@@ -294,7 +294,7 @@
 
         // update model if text changes
         textChangeEvent = editor.on('text-change', function (delta, oldDelta, source) {
-          var html = editorElem.querySelector(".ql-editor").innerHTML
+          var html = editorElem.querySelector('.ql-editor').innerHTML
           var text = editor.getText()
           var content = editor.getContents()
 


### PR DESCRIPTION
If a browser extension (for example [LanguageTool](https://addons.mozilla.org/ru/firefox/addon/languagetool/)) prepends some DOM Element to `.ql-container`, ng-quill won't get html correctly.

The html code after LanguageTool modifications looks like this:

```html
<div class="ql-container ql-snow" style="position: relative;">
   <lt-highlighter contenteditable="false" style="z-index: 1;">
      ...
   </lt-highlighter>
   <div class="ql-editor" data-gramm="false" contenteditable="true" spellcheck="false">
      <p>test</p>
   </div>
   <div class="ql-clipboard" contenteditable="true" tabindex="-1"></div>
   <div class="ql-tooltip ql-hidden" style="margin-top: 0px;">...</div>
</div>
```

The solution is to find `.ql-editor` element by a selector.