### PR TITLE
Returns the whole ng-quill module instead of function name.

### DIFF
--- a/src/ng-quill.js
+++ b/src/ng-quill.js
@@ -406,5 +406,5 @@
     }]
   })
 
-  return app.name
+  return app;
 }))


### PR DESCRIPTION
app.name is causing ng-quill package to return just a string due to which i was'nt able to return the properties of the module.